### PR TITLE
Fix types not being emitted

### DIFF
--- a/packages/stellis/src/jsx.ts
+++ b/packages/stellis/src/jsx.ts
@@ -12,7 +12,7 @@ import * as csstype from 'csstype';
  * https://github.com/ryansolid/dom-expressions/blob/main/packages/dom-expressions/src/jsx.d.ts
  */
 
-export namespace JSX {
+export declare namespace JSX {
   type Booleanish = boolean | 'true' | 'false';
   type OverloadedBoolean = boolean | string;
   type Element =


### PR DESCRIPTION
I was trying to use this package but noticed that the JSX types are missing in dist/.

As it turns out tsc ([used in pridepack to generate type declaration](https://github.com/LyonInc/pridepack/blob/master/packages/pridepack/src/core/compile-types.ts)) does not copy over .d.ts files. (see https://stackoverflow.com/questions/56018167/typescript-does-not-copy-d-ts-files-to-build)

This PR fixes the problem for this package.

I love the idea behind this package, I found it half way through writing my own.